### PR TITLE
fix: wrong logic for unloaded save files

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -61,7 +61,7 @@ function matchMode(item) {
   }
 
   // BEFORE loading a save -> show all
-  if (currentLoadedSaveFile !== undefined) {
+  if (currentLoadedSaveFile === undefined) {
     return true;
   }
 


### PR DESCRIPTION
This was a bug as a result of #50 (my fault).