### PR TITLE
fix: Shardillard numbering

### DIFF
--- a/src/data/mini-bosses.json
+++ b/src/data/mini-bosses.json
@@ -732,7 +732,7 @@
           "flag": "Shell Fossil Mimic",
           "icon": "mini-bosses/Shardillard.png",
           "id": "Shardillard_6",
-          "label": "Kill #5",
+          "label": "Kill #6",
           "link": "https://hollowknight.wiki/w/Shardillard#Location",
           "map": "https://mapgenie.io/hollow-knight-silksong/maps/pharloom?locationIds=479731",
           "scene": "Bone_East_14",


### PR DESCRIPTION
One of the Shardillard kills was miss-numbered.